### PR TITLE
Reduce image size with multi stage build and fix dependency in alpine-full

### DIFF
--- a/21.5/Dockerfile
+++ b/21.5/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-slim
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-slim AS compile-image
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -8,27 +9,40 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 # version definition
 ARG PYATS_VERSION=21.5
 
+# create virtualenv and install pyats packages
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential
+RUN pip3 install --upgrade --no-cache-dir setuptools pip virtualenv
+RUN virtualenv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir pyats~=${PYATS_VERSION}.0 genie~=${PYATS_VERSION}.0
+
 # tini version
 ENV TINI_VERSION 0.18.0
 
-# 1. install common tools
-# 2. use tini as subreaper in Docker container to adopt zombie processes
-# 3. update packages in system python
-# 4. create virtual environment
-#    - install pyats packages
-#    - create user directory
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini
+RUN chmod +x /bin/tini
+
+FROM python:3.6-slim
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definition
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# use tini as subreaper in Docker container to adopt zombie processes
+COPY --from=compile-image /bin/tini /bin/tini
+
+# install common tools
 RUN apt-get update \
- && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential\
- && curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini \
- && chmod +x /bin/tini \
- && pip3 install --upgrade --no-cache-dir setuptools pip virtualenv \
- && virtualenv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir pyats~=${PYATS_VERSION}.0 genie~=${PYATS_VERSION}.0 \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && apt-get remove -y curl build-essential\
- && apt-get autoremove -y\
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && apt-get clean \
+ && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
 # modify entrypoint

--- a/21.5/Dockerfile
+++ b/21.5/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6-slim AS compile-image
-LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+FROM python:3.6-slim AS builder
+LABEL stage=builder
 # build container for virtualenv
 
 # workspace location
@@ -34,11 +34,11 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy virtualenv containing installed pyats packages into this image
-COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
 RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
 
 # use tini as subreaper in Docker container to adopt zombie processes
-COPY --from=compile-image /bin/tini /bin/tini
+COPY --from=builder /bin/tini /bin/tini
 
 # install common tools
 RUN apt-get update \

--- a/21.5/alpine-full/Dockerfile
+++ b/21.5/alpine-full/Dockerfile
@@ -21,6 +21,7 @@ ADD src /src
 RUN apk add --no-cache busybox-extras openssh-client \
  && apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		cargo \
 		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
@@ -28,15 +29,18 @@ RUN apk add --no-cache busybox-extras openssh-client \
 		gcc \
 		gdbm-dev \
 		libc-dev \
+		libressl-dev \
 		libffi-dev \
 		libnsl-dev \
 		libtirpc-dev \
 		linux-headers \
 		make \
+		musl-dev \
 		ncurses-dev \
 		openssl-dev \
 		pax-utils \
 		readline-dev \
+		rust \
 		sqlite-dev \
 		tcl-dev \
 		tk \
@@ -50,7 +54,8 @@ RUN apk add --no-cache busybox-extras openssh-client \
  && ${WORKSPACE}/bin/pip install --no-cache-dir "$PYATS_WHL[full]" /src/* \
  && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
  && rm -rf /src \
- && apk del .build-deps
+ && apk del .build-deps \
+ && rm -rf ~/.cargo
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.5/alpine-full/Dockerfile
+++ b/21.5/alpine-full/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-alpine
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-alpine AS compile-image
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -9,17 +10,10 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy wheel files into this container
-ADD src /src
+COPY src /src
 
-# 1. install common tools
-# 2. install build dependencies
-# 3. create virtual environment
-#    - install pyats
-#    - create user directory
-#    - delete added unwanted files
-# 4. cleanup
-RUN apk add --no-cache busybox-extras openssh-client \
- && apk add --no-cache --virtual .build-deps  \
+RUN apk add --no-cache busybox-extras openssh-client
+RUN apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		cargo \
 		coreutils \
@@ -47,15 +41,27 @@ RUN apk add --no-cache busybox-extras openssh-client \
 		tk-dev \
 		util-linux-dev \
 		xz-dev \
-		zlib-dev \
- && python3 -m venv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && PYATS_WHL=`ls /src/pyats-* | head -n 1` \
- && ${WORKSPACE}/bin/pip install --no-cache-dir "$PYATS_WHL[full]" /src/* \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && rm -rf /src \
- && apk del .build-deps \
- && rm -rf ~/.cargo
+		zlib-dev
+RUN python3 -m venv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN PYATS_WHL=`ls /src/pyats-* | head -n 1` && ${WORKSPACE}/bin/pip install --no-cache-dir "$PYATS_WHL[full]" /src/*
+
+FROM python:3.6-alpine
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definitions
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# busybox-extras needed for telnet
+RUN apk add --no-cache busybox-extras openssh-client
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.5/alpine-full/Dockerfile
+++ b/21.5/alpine-full/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6-alpine AS compile-image
-LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+FROM python:3.6-alpine AS builder
+LABEL stage=builder
 # build container for virtualenv
 
 # workspace location
@@ -57,7 +57,7 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy virtualenv containing installed pyats packages into this image
-COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
 RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
 
 # busybox-extras needed for telnet

--- a/21.5/alpine-full/Makefile
+++ b/21.5/alpine-full/Makefile
@@ -18,9 +18,10 @@ image:
 	@echo "Building the builder $(NAME):$(TAG)"
 	@echo ""
 	@test -n "$(SRC)" || (echo "SRC variable not set. Use make image SRC=/path/to/src" ; exit 1)
+	@rm -rf ./src/
 	@cp -r $(SRC) ./src
 	@docker build -t $(NAME):$(TAG) .
-	@rm -rf src/
+	@rm -rf ./src/
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -29,4 +30,4 @@ clean:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Deleting src filder"
-	@rm -rf src/
+	@rm -rf ./src/

--- a/21.5/alpine/Dockerfile
+++ b/21.5/alpine/Dockerfile
@@ -53,7 +53,8 @@ RUN apk add --no-cache busybox-extras openssh-client \
  && ${WORKSPACE}/bin/pip install --no-cache-dir /src/* \
  && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
  && rm -rf /src \
- && apk del .build-deps
+ && apk del .build-deps \
+ && rm -rf ~/.cargo
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.5/alpine/Dockerfile
+++ b/21.5/alpine/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-alpine
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-alpine AS compile-image
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -9,17 +10,10 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy wheel files into this container
-ADD src /src
+COPY src /src
 
-# 1. install common tools
-# 2. install build dependencies
-# 3. create virtual environment
-#    - install pyats
-#    - create user directory
-#    - delete added unwanted files
-# 4. cleanup
-RUN apk add --no-cache busybox-extras openssh-client \
- && apk add --no-cache --virtual .build-deps  \
+RUN apk add --no-cache busybox-extras openssh-client
+RUN apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		cargo \
 		coreutils \
@@ -47,14 +41,27 @@ RUN apk add --no-cache busybox-extras openssh-client \
 		tk-dev \
 		util-linux-dev \
 		xz-dev \
-		zlib-dev \
- && python3 -m venv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && ${WORKSPACE}/bin/pip install --no-cache-dir /src/* \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && rm -rf /src \
- && apk del .build-deps \
- && rm -rf ~/.cargo
+		zlib-dev
+RUN python3 -m venv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir /src/*
+
+FROM python:3.6-alpine
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definitions
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# busybox-extras needed for telnet
+RUN apk add --no-cache busybox-extras openssh-client
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.5/alpine/Dockerfile
+++ b/21.5/alpine/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6-alpine AS compile-image
-LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+FROM python:3.6-alpine AS builder
+LABEL stage=builder
 # build container for virtualenv
 
 # workspace location
@@ -57,7 +57,7 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy virtualenv containing installed pyats packages into this image
-COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
 RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
 
 # busybox-extras needed for telnet

--- a/21.5/alpine/Makefile
+++ b/21.5/alpine/Makefile
@@ -18,9 +18,10 @@ image:
 	@echo "Building the builder $(NAME):$(TAG)"
 	@echo ""
 	@test -n "$(SRC)" || (echo "SRC variable not set. Use make image SRC=/path/to/src" ; exit 1)
+	@rm -rf ./src/
 	@cp -r $(SRC) ./src
 	@docker build -t $(NAME):$(TAG) .
-	@rm -rf src/
+	@rm -rf ./src/
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -29,4 +30,4 @@ clean:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Deleting src filder"
-	@rm -rf src/
+	@rm -rf ./src/

--- a/21.5/full/Dockerfile
+++ b/21.5/full/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-slim
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-slim AS compile-image
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -8,28 +9,40 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 # version definition
 ARG PYATS_VERSION=21.5
 
+# create virtualenv and install pyats packages
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential
+RUN pip3 install --upgrade --no-cache-dir setuptools pip virtualenv
+RUN virtualenv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir pyats[full]~=${PYATS_VERSION}.0 rest.connector~=${PYATS_VERSION}.0 yang.connector~=${PYATS_VERSION}.0
+
 # tini version
 ENV TINI_VERSION 0.18.0
 
-# 1. install common tools
-# 2. use tini as subreaper in Docker container to adopt zombie processes
-# 3. update packages in system python
-# 4. create virtual environment
-#    - install pyats packages
-#    - create user directory
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini
+RUN chmod +x /bin/tini
+
+FROM python:3.6-slim
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definition
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# use tini as subreaper in Docker container to adopt zombie processes
+COPY --from=compile-image /bin/tini /bin/tini
+
+# install common tools
 RUN apt-get update \
- && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential\
- && curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini \
- && chmod +x /bin/tini \
- && pip3 install --upgrade --no-cache-dir setuptools pip virtualenv \
- && virtualenv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && ${WORKSPACE}/bin/pip install --no-cache-dir pyats[full]~=${PYATS_VERSION}.0 rest.connector~=${PYATS_VERSION}.0 yang.connector~=${PYATS_VERSION}.0 \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && apt-get remove -y curl build-essential\
- && apt-get autoremove -y\
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && apt-get clean \
+ && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
 # modify entrypoint

--- a/21.5/full/Dockerfile
+++ b/21.5/full/Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.6-slim AS compile-image
-LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+FROM python:3.6-slim AS builder
+LABEL stage=builder
 # build container for virtualenv
 
 # workspace location
@@ -34,11 +34,11 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.5
 
 # copy virtualenv containing installed pyats packages into this image
-COPY --from=compile-image ${WORKSPACE} ${WORKSPACE}
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
 RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
 
 # use tini as subreaper in Docker container to adopt zombie processes
-COPY --from=compile-image /bin/tini /bin/tini
+COPY --from=builder /bin/tini /bin/tini
 
 # install common tools
 RUN apt-get update \

--- a/21.6/Dockerfile
+++ b/21.6/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-slim
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-slim AS builder
+LABEL stage=builder
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -8,27 +9,40 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 # version definition
 ARG PYATS_VERSION=21.6
 
+# create virtualenv and install pyats packages
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential
+RUN pip3 install --upgrade --no-cache-dir setuptools pip virtualenv
+RUN virtualenv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir pyats~=${PYATS_VERSION}.0 genie~=${PYATS_VERSION}.0
+
 # tini version
 ENV TINI_VERSION 0.18.0
 
-# 1. install common tools
-# 2. use tini as subreaper in Docker container to adopt zombie processes
-# 3. update packages in system python
-# 4. create virtual environment
-#    - install pyats packages
-#    - create user directory
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini
+RUN chmod +x /bin/tini
+
+FROM python:3.6-slim
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definition
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# use tini as subreaper in Docker container to adopt zombie processes
+COPY --from=builder /bin/tini /bin/tini
+
+# install common tools
 RUN apt-get update \
- && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential\
- && curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini \
- && chmod +x /bin/tini \
- && pip3 install --upgrade --no-cache-dir setuptools pip virtualenv \
- && virtualenv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir pyats~=${PYATS_VERSION}.0 genie~=${PYATS_VERSION}.0 \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && apt-get remove -y curl build-essential\
- && apt-get autoremove -y\
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && apt-get clean \
+ && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
 # modify entrypoint

--- a/21.6/alpine-full/Dockerfile
+++ b/21.6/alpine-full/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-alpine
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-alpine AS builder
+LABEL stage=builder
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -9,18 +10,12 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.6
 
 # copy wheel files into this container
-ADD src /src
+COPY src /src
 
-# 1. install common tools
-# 2. install build dependencies
-# 3. create virtual environment
-#    - install pyats
-#    - create user directory
-#    - delete added unwanted files
-# 4. cleanup
-RUN apk add --no-cache busybox-extras openssh-client \
- && apk add --no-cache --virtual .build-deps  \
+RUN apk add --no-cache busybox-extras openssh-client
+RUN apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
+		cargo \
 		coreutils \
 		dpkg-dev dpkg \
 		expat-dev \
@@ -33,24 +28,39 @@ RUN apk add --no-cache busybox-extras openssh-client \
 		libtirpc-dev \
 		linux-headers \
 		make \
+		musl-dev \
 		ncurses-dev \
 		openssl-dev \
 		pax-utils \
 		readline-dev \
+		rust \
 		sqlite-dev \
 		tcl-dev \
 		tk \
 		tk-dev \
 		util-linux-dev \
 		xz-dev \
-		zlib-dev \
- && python3 -m venv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && PYATS_WHL=`ls /src/pyats-* | head -n 1` \
- && ${WORKSPACE}/bin/pip install --no-cache-dir "$PYATS_WHL[full]" /src/* \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && rm -rf /src \
- && apk del .build-deps
+		zlib-dev
+RUN python3 -m venv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN PYATS_WHL=`ls /src/pyats-* | head -n 1` && ${WORKSPACE}/bin/pip install --no-cache-dir "$PYATS_WHL[full]" /src/*
+
+FROM python:3.6-alpine
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definitions
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# busybox-extras needed for telnet
+RUN apk add --no-cache busybox-extras openssh-client
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.6/alpine-full/Makefile
+++ b/21.6/alpine-full/Makefile
@@ -18,9 +18,10 @@ image:
 	@echo "Building the builder $(NAME):$(TAG)"
 	@echo ""
 	@test -n "$(SRC)" || (echo "SRC variable not set. Use make image SRC=/path/to/src" ; exit 1)
+	@rm -rf ./src/
 	@cp -r $(SRC) ./src
 	@docker build -t $(NAME):$(TAG) .
-	@rm -rf src/
+	@rm -rf ./src/
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -29,4 +30,4 @@ clean:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Deleting src filder"
-	@rm -rf src/
+	@rm -rf ./src/

--- a/21.6/alpine/Dockerfile
+++ b/21.6/alpine/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-alpine
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-alpine AS builder
+LABEL stage=builder
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -9,17 +10,10 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 ARG PYATS_VERSION=21.6
 
 # copy wheel files into this container
-ADD src /src
+COPY src /src
 
-# 1. install common tools
-# 2. install build dependencies
-# 3. create virtual environment
-#    - install pyats
-#    - create user directory
-#    - delete added unwanted files
-# 4. cleanup
-RUN apk add --no-cache busybox-extras openssh-client \
- && apk add --no-cache --virtual .build-deps  \
+RUN apk add --no-cache busybox-extras openssh-client
+RUN apk add --no-cache --virtual .build-deps  \
 		bzip2-dev \
 		cargo \
 		coreutils \
@@ -46,13 +40,27 @@ RUN apk add --no-cache busybox-extras openssh-client \
 		tk-dev \
 		util-linux-dev \
 		xz-dev \
-		zlib-dev \
- && python3 -m venv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && ${WORKSPACE}/bin/pip install --no-cache-dir /src/* \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && rm -rf /src \
- && apk del .build-deps
+		zlib-dev
+RUN python3 -m venv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir /src/*
+
+FROM python:3.6-alpine
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definitions
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# busybox-extras needed for telnet
+RUN apk add --no-cache busybox-extras openssh-client
 
 # modify entrypoint
 COPY docker-entrypoint.sh /entrypoint.sh

--- a/21.6/alpine/Makefile
+++ b/21.6/alpine/Makefile
@@ -18,9 +18,10 @@ image:
 	@echo "Building the builder $(NAME):$(TAG)"
 	@echo ""
 	@test -n "$(SRC)" || (echo "SRC variable not set. Use make image SRC=/path/to/src" ; exit 1)
+	@rm -rf ./src/
 	@cp -r $(SRC) ./src
 	@docker build -t $(NAME):$(TAG) .
-	@rm -rf src/
+	@rm -rf ./src/
 	@echo ""
 	@echo "Done."
 	@echo ""
@@ -29,4 +30,4 @@ clean:
 	@echo ""
 	@echo "--------------------------------------------------------------------"
 	@echo "Deleting src filder"
-	@rm -rf src/
+	@rm -rf ./src/

--- a/21.6/full/Dockerfile
+++ b/21.6/full/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-slim
-MAINTAINER pyATS Support <pyats-support-ext@cisco.com>
+FROM python:3.6-slim AS builder
+LABEL stage=builder
+# build container for virtualenv
 
 # workspace location
 ARG WORKSPACE
@@ -8,28 +9,40 @@ ENV WORKSPACE ${WORKSPACE:-/pyats}
 # version definition
 ARG PYATS_VERSION=21.6
 
+# create virtualenv and install pyats packages
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential
+RUN pip3 install --upgrade --no-cache-dir setuptools pip virtualenv
+RUN virtualenv ${WORKSPACE}
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel
+RUN ${WORKSPACE}/bin/pip install --no-cache-dir pyats[full]~=${PYATS_VERSION}.0 rest.connector~=${PYATS_VERSION}.0 yang.connector~=${PYATS_VERSION}.0
+
 # tini version
 ENV TINI_VERSION 0.18.0
 
-# 1. install common tools
-# 2. use tini as subreaper in Docker container to adopt zombie processes
-# 3. update packages in system python
-# 4. create virtual environment
-#    - install pyats packages
-#    - create user directory
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini
+RUN chmod +x /bin/tini
+
+FROM python:3.6-slim
+LABEL maintainer="pyATS Support <pyats-support-ext@cisco.com>"
+
+# workspace location
+ARG WORKSPACE
+ENV WORKSPACE ${WORKSPACE:-/pyats}
+
+# version definition
+ARG PYATS_VERSION=21.5
+
+# copy virtualenv containing installed pyats packages into this image
+COPY --from=builder ${WORKSPACE} ${WORKSPACE}
+RUN mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users
+
+# use tini as subreaper in Docker container to adopt zombie processes
+COPY --from=builder /bin/tini /bin/tini
+
+# install common tools
 RUN apt-get update \
- && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client curl build-essential\
- && curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini \
- && chmod +x /bin/tini \
- && pip3 install --upgrade --no-cache-dir setuptools pip virtualenv \
- && virtualenv ${WORKSPACE} \
- && ${WORKSPACE}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel \
- && ${WORKSPACE}/bin/pip install --no-cache-dir pyats[full]~=${PYATS_VERSION}.0 rest.connector~=${PYATS_VERSION}.0 yang.connector~=${PYATS_VERSION}.0 \
- && mkdir ${WORKSPACE}/users && chmod 775 ${WORKSPACE}/users \
- && apt-get remove -y curl build-essential\
- && apt-get autoremove -y\
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- && apt-get clean \
+ && apt-get install -y --no-install-recommends iputils-ping telnet openssh-client \
  && rm -rf /var/lib/apt/lists/*
 
 # modify entrypoint


### PR DESCRIPTION
Use multi stage build to reduce size of images.

Alpine images are reduced by about 60mb because `ADD src /src` no longer creates a layer, and debian images are reduced by about 35mb because some temporary build files dont appear anymore in the final image.

```
21.5:          585MB    549MB
alpine:        426MB    363MB
alpine-full:   761MB    698MB
full:          962MB    925MB
```

Also alpine-full must build cryptography wheel which requires rust at build time, so add this to alpine-full